### PR TITLE
Added option to include form values in the respondent notification email

### DIFF
--- a/About.html
+++ b/About.html
@@ -1,6 +1,10 @@
 <link rel="stylesheet" href="https://ssl.gstatic.com/docs/script/css/add-ons1.css">
 <div>
   <p>
+  This version of <i>Form Notifications</i> is a fork of <i>Form Notifications</i> (https://github.com/googlesamples/apps-script-form-notifications-addon).
+  It added the possibility to add the form content to the respondent notification email so that the end-user has a copy of what he filled out.
+  </p>
+  <p>
   <i>Form Notifications</i> was created as an sample add-on, and is meant
   for demonstration purposes only. It should not be used for complex or
   important workflows.

--- a/Code.gs
+++ b/Code.gs
@@ -128,7 +128,8 @@ function adjustFormSubmitTrigger() {
   var settings = PropertiesService.getDocumentProperties();
   var triggerNeeded =
       settings.getProperty('creatorNotify') == 'true' ||
-      settings.getProperty('respondentNotify') == 'true';
+      settings.getProperty('respondentNotify') == 'true' ||
+      settings.getProperty('sendContentsToRespondent') == 'true'  ;
 
   // Create a new trigger if required; delete existing trigger
   //   if it is not needed.
@@ -271,19 +272,33 @@ function sendRespondentNotification(response) {
   var settings = PropertiesService.getDocumentProperties();
   var emailId = settings.getProperty('respondentEmailItemId');
   var emailItem = form.getItemById(parseInt(emailId));
+  var contentString = "";
+  if(settings.getProperty('sendContentsToRespondent')  == 'true') {
+    contentString += "Your response was: \n";
+    var itemResponses = response.getItemResponses();
+    for (var j = 0; j < itemResponses.length; j++) {
+       var itemResponse = itemResponses[j];
+       // Logger.log('Response #%s to the question "%s" was "%s"', (i + 1).toString(), itemResponse.getItem().getTitle(), itemResponse.getResponse());
+      contentString +=  "    " + String(itemResponse.getItem().getTitle()) + ": " + String(itemResponse.getResponse()) + "\n";
+    };
+    contentString += "\n";
+  } else {   
+    contentString += "Your response is not included.\n";
+  }
   var respondentEmail = response.getResponseForItem(emailItem)
       .getResponse();
   if (respondentEmail) {
     var template =
         HtmlService.createTemplateFromFile('RespondentNotification');
     template.paragraphs = settings.getProperty('responseText').split('\n');
+    template.responseData = contentString.split('\n');
     template.notice = NOTICE;
     var message = template.evaluate();
     MailApp.sendEmail(respondentEmail,
         settings.getProperty('responseSubject'),
-        message.getContent(), {
+        (message.getContent()), {
           name: form.getTitle(),
-            htmlBody: message.getContent()
+            htmlBody: (message.getContent())
         });
   }
 }

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ Form Notifications Add-on for Google Forms
 
 A sample Google Apps Script add-on for Google Forms.
 
+This version is a fork of <i>Form Notifications</i> 
+(https://github.com/googlesamples/apps-script-form-notifications-addon).
+It added the possibility to add the form content to the respondent 
+notification email so that the end-user has a copy of what he filled out.
+
 Introduction
 ------------
 

--- a/RespondentNotification.html
+++ b/RespondentNotification.html
@@ -2,6 +2,13 @@
   <p><?= paragraphs[i] ?></p>
 <? } ?>
 
+
+<hr>
+
+<? for (var i = 0; i < responseData.length; i++) { ?>
+  <p style="font-size:90%"; line-height: 90%;><?= responseData[i] ?></p>
+<? } ?>
+
 <hr>
 
 <p style="font-size:80%">This automatic message was sent to you via the <i>Form

--- a/Sidebar.html
+++ b/Sidebar.html
@@ -6,28 +6,23 @@
   bottom: 54px;
   top: 0;
 }
-
 .branding-text {
   left: 7px;
   position: relative;
   top: 3px;
 }
-
 .logo {
   vertical-align: middle;
 }
-
 .width-100 {
   width: 100%;
   box-sizing: border-box;
   -webkit-box-sizing : border-box;‌
   -moz-box-sizing : border-box;
 }
-
 label {
   font-weight: bold;
 }
-
 #creator-options,
 #respondent-options {
   background-color: #eee;
@@ -36,18 +31,15 @@ label {
   border-style: solid;
   display: none;
 }
-
 #creator-email,
 #respondent-email,
 #button-bar,
 #submit-subject {
   margin-bottom: 10px;
 }
-
 #response-step {
   display: inline;
 }
-
 </style>
 
 <div class="sidebar branding-below">
@@ -82,6 +74,8 @@ label {
       <label for="submit-notice">Notification email body:</label>
       <textarea rows="8" cols="40" id="submit-notice"
           class="width-100"></textarea>
+      <input type="checkbox" id="send-contents-to-respondent">
+      <label for="send-contents-to-respondent">Send contents to respondent</label>
     </div>
 
     <div class="block" id="button-bar">
@@ -107,6 +101,7 @@ label {
     $('#save-settings').click(saveSettingsToServer);
     $('#creator-notify').click(toggleCreatorNotify);
     $('#respondent-notify').click(toggleRespondentNotify);
+//    $('#send-contents-to-respondent').click(toggleSendContentsToRespondent);
     $('#response-step').change(validateNumber);
     google.script.run
        .withSuccessHandler(loadSettings)
@@ -114,7 +109,6 @@ label {
        .withUserObject($('#button-bar').get())
        .getSettings();
   });
-
   /**
    * Callback function that populates the notification options using
    * previously saved values.
@@ -131,15 +125,16 @@ label {
     $('#submit-notice').val(!settings.responseText ?
        'Thank you for responding to our form!' :
        settings.responseText);
-
     if (settings.creatorNotify === 'true') {
       $('#creator-notify').prop('checked', true);
       $('#creator-options').show();
     }
-
     if (settings.respondentNotify === 'true') {
       $('#respondent-notify').prop('checked', true);
       $('#respondent-options').show();
+    }
+    if (settings.sendContentsToRespondent === 'true') {
+      $('#send-contents-to-respondent').prop('checked', true);
     }
 
     // Fill the respondent email select box with the
@@ -154,6 +149,13 @@ label {
     $('#respondent-email').val(settings.respondentEmailItemId);
   }
 
+  /*
+  function toggleSendContentsToRespondent() {
+    if ($('#send-contents-to-respondent').is(':checked')) {
+    }
+  }
+  */
+  
   /**
    * Toggles the visibility of the form creator notification options.
    */
@@ -165,7 +167,6 @@ label {
       $('#creator-options').hide();
     }
   }
-
   /**
    * Toggles the visibility of the form sumbitter notification options.
    */
@@ -177,7 +178,6 @@ label {
       $('#respondent-options').hide();
     }
   }
-
   /**
    * Ensures that the entered step is a number between 1
    * and 99999, inclusive.
@@ -192,7 +192,6 @@ label {
       $('#response-step').val(99999);
     }
   }
-
   /**
    * Collects the options specified in the add-on sidebar and sends them to
    * be saved as Properties on the server.
@@ -202,16 +201,16 @@ label {
     $('#status').remove();
     var creatorNotify = $('#creator-notify').is(':checked');
     var respondentNotify = $('#respondent-notify').is(':checked');
+    var sendContentsToRespondent = $('#send-contents-to-respondent').is(':checked');
     var settings = {
       'creatorNotify': creatorNotify,
-      'respondentNotify': respondentNotify
+      'respondentNotify': respondentNotify,
+      'sendContentsToRespondent': sendContentsToRespondent
     };
-
     // Only save creator options if notify is turned on
     if (creatorNotify) {
       settings.responseStep = $('#response-step').val();
       settings.creatorEmail = $('#creator-email').val().trim();
-
       // Abort save if entered email is blank
       if (!settings.creatorEmail) {
         showStatus('Enter an owner email', $('#button-bar'));
@@ -219,14 +218,13 @@ label {
         return;
       }
     }
-
     // Only save respondent options if notify is turned on
     if (respondentNotify) {
       settings.respondentEmailItemId = $('#respondent-email').val();
       settings.responseSubject = $('#submit-subject').val();
       settings.responseText = $('#submit-notice').val();
+      settings.sendContentsToRespondent = $('#send-contents-to-respondent').is(':checked');
     }
-
     // Save the settings on the server
     google.script.run
         .withSuccessHandler(
@@ -242,7 +240,6 @@ label {
         .withUserObject(this)
         .saveSettings(settings);
   }
-
   /**
    * Inserts a div that contains an status message after a given element.
    *


### PR DESCRIPTION
Added option to include form content (end-user responses) in the respondent notification email so that end-user knows (and has a copy) of what he/she filled out.

If you like the change consider adopting them. Thank you.

In the Google Forms Add-On configuration screen for "Form Notifications" there is a new checkmark which can be selected. If selected, <b>all</b> fields of the form, i.e. the full response, is included in the respondent notification email.
